### PR TITLE
Change to use the PHP session name and not the hardcoded

### DIFF
--- a/exceptional/data.php
+++ b/exceptional/data.php
@@ -48,7 +48,8 @@ class ExceptionalData {
             // sanitize headers
             $headers = getallheaders();
             if (isset($headers["Cookie"])) {
-              $headers["Cookie"] = preg_replace("/PHPSESSID=\S+/", "PHPSESSID=[FILTERED]", $headers["Cookie"]);
+              $sessionKey = preg_quote(function_exists("ini_get") ? ini_get("session.name") : "PHPSESSID", "/");
+              $headers["Cookie"] = preg_replace("/$sessionKey=\S+/", "$sessionKey=[FILTERED]", $headers["Cookie"]);
             }
 
             $server = $_SERVER;


### PR DESCRIPTION
By default PHP use PHPSESSID, but in some environments it is different. So I changed to read from ini what is the current session name. If is good that fix the name to different frameworks that change this name.
